### PR TITLE
Updated paper citation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Datasets:
 * [Flickr](http://socialcomputing.asu.edu/datasets/Flickr)
 * [YouTube](http://socialcomputing.asu.edu/datasets/YouTube)
 * [BlogCatalog](http://socialcomputing.asu.edu/datasets/BlogCatalog)
-* [Paper Citation and Coauthorship](http://cse.iitkgp.ac.in/~tanmoyc/Papers/ASONAM_2013.pdf)
+* [Paper Citation and Coauthorship](https://dl.acm.org/citation.cfm?id=3191523)
 * [POS](http://snap.stanford.edu/node2vec/POS.mat)


### PR DESCRIPTION
The old link pointed to a paper from 2013, which I think is not what you wanted.